### PR TITLE
Add log level methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@ const log = new LogToSheet({
   maxBuffer: 1000
 });
 ```
-Insert new logs by calling the  ```insert``` method with 1 argument which is the value to log. 
+Insert new logs by calling the  ```insert``` method with 1 argument which is the value to log.  
+You can also log with standard levels using `info`, `debug`, `warn`, and `error`.
 ```
 log.insert("My first log");
+log.info("App started");
+log.debug("Debug details");
+log.warn("Something looks off");
+log.error("Something failed");
 ```
 Output the logs to the sheet by calling `flush`. `flush` will attempt to create
 the output sheet if it does not already exist. `flush` is also automatically
@@ -28,7 +33,7 @@ invoked when more than the configured `maxBuffer` value (default 500) entries ha
 log.flush();
 ```
 ## Output Format
-LogToSheet will output 2 columns to the sheet. The first column is a date time corresponding to the time of the log in ```yyyy-MM-dd HH:mm:ss``` format using the configured `timeZone` (defaults to UTC). The second column is the log.
+Log entries written with the level methods contain 3 columns: the timestamp, the level, and the message. Entries written with `insert()` continue to produce 2 columns (timestamp and message).
 ## Example
 ```
 const log = new LogToSheet({
@@ -38,9 +43,10 @@ const log = new LogToSheet({
 });
 
 for(let i = 1; i <= 100; i++) {
-  log.insert(`Demo ${i}`);
+  log.debug(`Processing ${i}`);
 }
 
+log.info('All done');
 log.flush();
 ```
 <img width="230" alt="Screenshot 2023-01-21 134153" src="https://user-images.githubusercontent.com/49938659/213867317-d355350c-ea0e-4b2f-94bc-1e7ae6a32dc7.png">

--- a/logToSheet.js
+++ b/logToSheet.js
@@ -48,18 +48,60 @@ class LogToSheet {
   }
 
   /**
+   * Logs a message with a specific level.
+   * @param {string} level - The log level.
+   * @param {*} message - The message to log.
+   * @private
+   */
+  _logWithLevel(level, message) {
+    if (message == null) return;
+    var timestamp = Utilities.formatDate(new Date(), this.timeZone, "yyyy-MM-dd HH:mm:ss");
+    this.logs.push([timestamp, level, String(message)]);
+    if (this.logs.length >= this.maxBuffer) {
+      this.flush();
+    }
+  }
+
+  /** Log a message at INFO level */
+  info(message) {
+    this._logWithLevel("INFO", message);
+  }
+
+  /** Log a message at DEBUG level */
+  debug(message) {
+    this._logWithLevel("DEBUG", message);
+  }
+
+  /** Log a message at WARN level */
+  warn(message) {
+    this._logWithLevel("WARN", message);
+  }
+
+  /** Log a message at ERROR level */
+  error(message) {
+    this._logWithLevel("ERROR", message);
+  }
+
+  /**
    * Writes queued logs to the sheet.
    */
   flush() {
     if (this.logs.length === 0) return;
     if (this.sheet == null) {
-      this.sheet = this.spreadsheet.insertSheet(this.sheetName);
+      this.sheet = this.spreadsheet.getSheetByName(this.sheetName) || this.spreadsheet.insertSheet(this.sheetName);
     }
+
+    // Add header when empty and using level logs
+    if (this.sheet.getLastRow() === 0 && this.logs[0].length === 3) {
+      this.sheet.appendRow(['Timestamp', 'Level', 'Message']);
+    }
+
     var lastRow = this.sheet.getLastRow();
     if (lastRow + this.logs.length > this.sheet.getMaxRows()) {
       this.sheet.insertRowsAfter(lastRow, this.logs.length);
     }
-    var range = this.sheet.getRange(lastRow + 1, 1, this.logs.length, this.logs[0].length);
+    var colCount = this.logs[0].length;
+    var range = this.sheet.getRange(lastRow + 1, 1, this.logs.length, colCount);
     range.setValues(this.logs);
     this.logs = [];
   }


### PR DESCRIPTION
## Summary
- implement `info`, `debug`, `warn`, and `error` helpers in `LogToSheet`
- add internal `_logWithLevel` implementation
- extend `flush` to support three-column log entries
- document new methods and usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b5afa4a4883248002d530ba33d377